### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ target
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 *.html
 *.keystore

--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ projects: [spring-framework, spring-hateoas, spring-security, spring-security-oa
 :project_id: tut-rest
 :icons: font
 :source-highlighter: prettify
-:javaee-api-root: http://docs.oracle.com/javaee/7/api/
+:javaee-api-root: https://docs.oracle.com/javaee/7/api/
 :image-width: 500
 :book-root: .
 
@@ -43,7 +43,7 @@ we will use the Spring portfolio to build a RESTful service while leveraging the
 
 == Getting Started
 
-As we work through this tutorial, we'll use https://spring.io/projects/spring-boot[Spring Boot]. Go to http://start.spring.io/[Spring Initializr] and select the following:
+As we work through this tutorial, we'll use https://spring.io/projects/spring-boot[Spring Boot]. Go to https://start.spring.io/[Spring Initializr] and select the following:
 
 * Web
 * JPA


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://stateless.co/hal_specification.html (200) with 1 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.oracle.com/javaee/7/api/ with 1 occurrences migrated to:  
  https://docs.oracle.com/javaee/7/api/ ([https](https://docs.oracle.com/javaee/7/api/) result 200).
* [ ] http://start.spring.io/ with 1 occurrences migrated to:  
  https://start.spring.io/ ([https](https://start.spring.io/) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/employees with 7 occurrences
* http://localhost:8080/employees/1 with 3 occurrences
* http://localhost:8080/employees/2 with 1 occurrences
* http://localhost:8080/employees/3 with 5 occurrences
* http://localhost:8080/orders with 5 occurrences
* http://localhost:8080/orders/3 with 1 occurrences
* http://localhost:8080/orders/4 with 2 occurrences
* http://localhost:8080/orders/4/cancel with 3 occurrences
* http://localhost:8080/orders/4/complete with 1 occurrences