### PR TITLE
Bump to 2.1.4 spring-boot-starter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.5.RELEASE</version>
+		<version>2.1.4.RELEASE</version>
 	</parent>
 
 	<groupId>org.springframework.guides</groupId>


### PR DESCRIPTION
This prevents InvocationTargetException in spring-boot-maven-plugin
Fixes #78