### PR TITLE
Adding necessary import statements to hateaos introduction.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -316,6 +316,13 @@ A critical ingredient to any RESTful service is adding https://tools.ietf.org/ht
 include::rest/src/main/java/payroll/EmployeeController.java[tag=get-single-item]
 ----
 
+.Relevant import statements
+[source,java,tabsize=2,indent=0]
+----
+include::rest/src/main/java/payroll/EmployeeController.java[tag=hateoas-imports]
+----
+
+
 This is very similar to what we had before, but a few things have changed:
 
 * The return type of the method has changed from `Employee` to `Resource<Employee>`. `Resource<T>` is a generic container from Spring HATEOAS that includes not only the data but a collection of links.

--- a/rest/src/main/java/payroll/EmployeeController.java
+++ b/rest/src/main/java/payroll/EmployeeController.java
@@ -1,12 +1,15 @@
 package payroll;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+// tag::hateoas-imports[]
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
+// end::hateoas-imports[]
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;


### PR DESCRIPTION
Currently there are no mention of hateoas imports for `EmployeeConstructor.java`. This PR introduces a snippet of the imports in the example code into the tutorial.