### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -335,6 +335,9 @@ include::rest/src/main/java/payroll/EmployeeController.java[tag=get-single-item]
 [NOTE]
 ====
 This tutorial is based on Spring MVC and uses the static helper methods from `WebMvcLinkBuilder` to build these links.
+
+Required import: `import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;`
+
 If you are using Spring WebFlux in your project, you must instead use `WebFluxLinkBuilder`.
 ====
 


### PR DESCRIPTION
Hi, 

Added "Required import:` import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;`" as a NOTE in the README.adoc file.

It will help users of this guide fix the following error:

**The method methodOn(Class) is undefined for the type EmployeeController.**

Hope you find it useful ...