### PR TITLE
Use RestControllerAdvice annotation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -170,7 +170,7 @@ When an `EmployeeNotFoundException` is thrown, this extra tidbit of Spring MVC c
 include::nonrest/src/main/java/payroll/EmployeeNotFoundAdvice.java[]
 ----
 
-* `@ResponseBody` signals that this advice is rendered straight into the response body.
+* `@RestControllerAdvice` signals that this advice is rendered straight into the response body.
 * `@ExceptionHandler` configures the advice to only respond if an `EmployeeNotFoundException` is thrown.
 * `@ResponseStatus` says to issue an `HttpStatus.NOT_FOUND`, i.e. an *HTTP 404*.
 * The body of the advice generates the content. In this case, it gives the message of the exception.

--- a/evolution/src/main/java/payroll/EmployeeNotFoundAdvice.java
+++ b/evolution/src/main/java/payroll/EmployeeNotFoundAdvice.java
@@ -1,15 +1,13 @@
 package payroll;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+@RestControllerAdvice
 class EmployeeNotFoundAdvice {
 
-	@ResponseBody
 	@ExceptionHandler(EmployeeNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	String employeeNotFoundHandler(EmployeeNotFoundException ex) {

--- a/links/src/main/java/payroll/EmployeeNotFoundAdvice.java
+++ b/links/src/main/java/payroll/EmployeeNotFoundAdvice.java
@@ -1,15 +1,13 @@
 package payroll;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+@RestControllerAdvice
 class EmployeeNotFoundAdvice {
 
-	@ResponseBody
 	@ExceptionHandler(EmployeeNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	String employeeNotFoundHandler(EmployeeNotFoundException ex) {

--- a/nonrest/src/main/java/payroll/EmployeeNotFoundAdvice.java
+++ b/nonrest/src/main/java/payroll/EmployeeNotFoundAdvice.java
@@ -1,15 +1,13 @@
 package payroll;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+@RestControllerAdvice
 class EmployeeNotFoundAdvice {
 
-	@ResponseBody
 	@ExceptionHandler(EmployeeNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	String employeeNotFoundHandler(EmployeeNotFoundException ex) {

--- a/rest/src/main/java/payroll/EmployeeNotFoundAdvice.java
+++ b/rest/src/main/java/payroll/EmployeeNotFoundAdvice.java
@@ -1,15 +1,13 @@
 package payroll;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+@RestControllerAdvice
 class EmployeeNotFoundAdvice {
 
-	@ResponseBody
 	@ExceptionHandler(EmployeeNotFoundException.class)
 	@ResponseStatus(HttpStatus.NOT_FOUND)
 	String employeeNotFoundHandler(EmployeeNotFoundException ex) {


### PR DESCRIPTION
Use the `RestControllerAdvice` annotation instead of the `ControllerAdvice` and `ResponseBody` combination. This should simplify implementation and provide greater visual consistency with the `RestController` annotation.