### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -398,7 +398,9 @@ You also need to include new imports:
 ====
 [source,java]
 ----
+import java.util.stream.Collectors;
 import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.CollectionModel;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 ----
 ====


### PR DESCRIPTION
The guide was missing these classes that are needed to be imported and it is not immediately obvious what is missing when you switch the @GetMapping for `/employees` further down in the guide. The IDE shows errors after changing the @GetMapping complaining about not finding the classes and the application would no longer run. It might save some time for beginners trying to work out whether they missed a step in the guide. I appreciate for people with more experience in Java might find this trivial.